### PR TITLE
allow the hostname to be configured through setup.ini or gcode

### DIFF
--- a/ESPWebDAV.cpp
+++ b/ESPWebDAV.cpp
@@ -108,7 +108,7 @@ void ESPWebDAV::handleRequest(String blank)	{
 	DBG_PRINT(" u: "); DBG_PRINTLN(uri);
 
 	// add header that gets sent everytime
-	sendHeader("DAV", "2");
+	sendHeader("DAV", "1, 2");
 
 	// handle properties
 	if(method.equals("PROPFIND"))

--- a/ESPWebDAV.ino
+++ b/ESPWebDAV.ino
@@ -25,19 +25,21 @@ void setup() {
   if(config.load() == 1) { // Connected before
     if(!network.start()) {
       SERIAL_ECHOLN("Connect fail, please check your INI file or set the wifi config and connect again");
-      SERIAL_ECHOLN("- M50: Set the wifi ssid , 'M50 ssid-name'");
-      SERIAL_ECHOLN("- M51: Set the wifi password , 'M51 password'");
-      SERIAL_ECHOLN("- M52: Start to connect the wifi");
-      SERIAL_ECHOLN("- M53: Check the connection status");
+      SERIAL_ECHOLN("- M50: Set WiFi SSID");
+      SERIAL_ECHOLN("- M51: Set WiFi Password");
+      SERIAL_ECHOLN("- M52: Connect");
+      SERIAL_ECHOLN("- M53: Connection Status");
+      SERIAL_ECHOLN("- M54: Set Hostname");
     }
   }
   else {
     SERIAL_ECHOLN("Welcome to FYSETC: www.fysetc.com");
     SERIAL_ECHOLN("Please set the wifi config first");
-    SERIAL_ECHOLN("- M50: Set the wifi ssid , 'M50 ssid-name'");
-    SERIAL_ECHOLN("- M51: Set the wifi password , 'M51 password'");
-    SERIAL_ECHOLN("- M52: Start to connect the wifi");
-    SERIAL_ECHOLN("- M53: Check the connection status");
+    SERIAL_ECHOLN("- M50: Set WiFi SSID");
+    SERIAL_ECHOLN("- M51: Set WiFi Password");
+    SERIAL_ECHOLN("- M52: Connect");
+    SERIAL_ECHOLN("- M53: Connection Status");
+    SERIAL_ECHOLN("- M54: Set Hostname");
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ GCode can be directly uploaded from the slicer (Cura) to this remote drive, ther
 
 ## Dependencies:
 1. [ESP8266 Arduino Core version 2.4](https://github.com/esp8266/Arduino)
-2. [SdFat library](https://github.com/greiman/SdFat)
+2. [SdFat library version 1.0.16](https://github.com/greiman/SdFat)
 
 
 ## Use:

--- a/config.cpp
+++ b/config.cpp
@@ -66,11 +66,23 @@ int Config::loadSD() {
         goto FAIL;
       }
     }
+    else if(sKEY == "HOSTNAME") {
+      SERIAL_ECHOLN("INI file : HOSTNAME found");
+      if(sValue.length()>0) {
+        memset(data._hostname,'\0',HOSTNAME_LEN);
+        sValue.toCharArray(data._hostname,HOSTNAME_LEN);
+        step++;
+      }
+      else {
+        rst = -7;
+        goto FAIL;
+      }
+    }
     else continue; // Bad line
   }
-  if(step != 2) { // We miss ssid or password
+  if(step != 3) { // We miss ssid or password
     //memset(data,) // TODO: do we need to empty the data?
-    SERIAL_ECHOLN("Please check your SSDI or PASSWORD in ini file");
+    SERIAL_ECHOLN("Please check your SSID, PASSWORD, and HOSTNAME in ini file");
     rst = -6;
     goto FAIL;
   }
@@ -123,14 +135,24 @@ void Config::password(char* password) {
   strncpy(data.psw,password,WIFI_PASSWD_LEN);
 }
 
-void Config::save(const char*ssid,const char*password) {
-  if(ssid ==NULL || password==NULL)
+char* Config::hostname() {
+  return data._hostname;
+}
+
+void Config::hostname(char* hostname) {
+  if (hostname==NULL) return;
+  strncpy(data._hostname, hostname, HOSTNAME_LEN);
+}
+
+void Config::save(const char*ssid,const char*password, const char* hostname) {
+  if(ssid ==NULL || password==NULL || hostname==NULL)
     return;
 
   EEPROM.begin(EEPROM_SIZE);
   data.flag = 1;
   strncpy(data.ssid, ssid, WIFI_SSID_LEN);
   strncpy(data.psw, password, WIFI_PASSWD_LEN);
+  strncpy(data._hostname, hostname, HOSTNAME_LEN);
   uint8_t *p = (uint8_t*)(&data);
   for (int i = 0; i < sizeof(data); i++)
   {
@@ -140,7 +162,7 @@ void Config::save(const char*ssid,const char*password) {
 }
 
 void Config::save() {
-  if(data.ssid == NULL || data.psw == NULL)
+  if(data.ssid == NULL || data.psw == NULL || data._hostname==NULL)
     return;
 
   EEPROM.begin(EEPROM_SIZE);

--- a/config.h
+++ b/config.h
@@ -6,14 +6,16 @@
 
 #define WIFI_SSID_LEN 32
 #define WIFI_PASSWD_LEN 64
+#define HOSTNAME_LEN 32
 
 #define EEPROM_SIZE 512
 
 typedef struct config_type
 {
   unsigned char flag; // Was saved before?
-  char ssid[32];
-  char psw[64];
+  char ssid[WIFI_SSID_LEN];
+  char psw[WIFI_PASSWD_LEN];
+  char _hostname[HOSTNAME_LEN];
 }CONFIG_TYPE;
 
 class Config	{
@@ -24,7 +26,9 @@ public:
   void ssid(char* ssid);
   char* password();
   void password(char* password);
-  void save(const char*ssid,const char*password);
+  char* hostname();
+  void hostname(char* hostname);
+  void save(const char*ssid,const char*password, const char* hostname);
   void save();
   int save_ip(const char *ip);
 

--- a/gcode.cpp
+++ b/gcode.cpp
@@ -122,10 +122,11 @@ void Gcode::gcode_M51() {
 void Gcode::gcode_M52() {
   if(!network.start()) {
     SERIAL_ECHOLN("Connect fail, please check your INI file or set the wifi config and connect again");
-    SERIAL_ECHOLN("- M50: Set the wifi ssid , 'M50 ssid-name'");
-    SERIAL_ECHOLN("- M51: Set the wifi password , 'M51 password'");
-    SERIAL_ECHOLN("- M52: Start to connect the wifi");
-    SERIAL_ECHOLN("- M53: Check the connection status");
+    SERIAL_ECHOLN("- M50: Set WiFi SSID");
+    SERIAL_ECHOLN("- M51: Set WiFi Password");
+    SERIAL_ECHOLN("- M52: Connect");
+    SERIAL_ECHOLN("- M53: Connection Status");
+    SERIAL_ECHOLN("- M54: Set Hostname");
   }
 }
 
@@ -135,10 +136,11 @@ void Gcode::gcode_M52() {
 void Gcode::gcode_M53() {
   if(WiFi.status() != WL_CONNECTED) {
     SERIAL_ECHOLN("Wifi not connected");
-    SERIAL_ECHOLN("- M50: Set the wifi ssid , 'M50 ssid-name'");
-    SERIAL_ECHOLN("- M51: Set the wifi password , 'M51 password'");
-    SERIAL_ECHOLN("- M52: Start to connect the wifi");
-    SERIAL_ECHOLN("- M53: Check the connection status");
+    SERIAL_ECHOLN("- M50: Set WiFi SSID");
+    SERIAL_ECHOLN("- M51: Set WiFi Password");
+    SERIAL_ECHOLN("- M52: Connect");
+    SERIAL_ECHOLN("- M53: Connection Status");
+    SERIAL_ECHOLN("- M54: Set Hostname");
   }
   else {
     SERIAL_ECHOLN("");
@@ -146,8 +148,18 @@ void Gcode::gcode_M53() {
     SERIAL_ECHO("IP address: "); SERIAL_ECHOLN(WiFi.localIP());
     SERIAL_ECHO("RSSI: "); SERIAL_ECHOLN(WiFi.RSSI());
     SERIAL_ECHO("Mode: "); SERIAL_ECHOLN(WiFi.getPhyMode());
-    SERIAL_ECHO("Asscess to SD at the Run prompt : \\\\"); SERIAL_ECHO(WiFi.localIP());SERIAL_ECHOLN("\\DavWWWRoot");
+    SERIAL_ECHO("Access to SD at the Run prompt : \\\\"); SERIAL_ECHO(config.hostname());SERIAL_ECHOLN("\\DavWWWRoot");
   }
+}
+
+/**
+ * M54: Set the hostname
+ */
+void Gcode::gcode_M54() {
+  for (char *fn = parser.string_arg; *fn; ++fn);
+  config.hostname(parser.string_arg);
+  SERIAL_ECHO("hostname: ");
+  SERIAL_ECHOLN(config.hostname());
 }
 
 /**
@@ -169,6 +181,7 @@ void Gcode::process_parsed_command() {
       case 51: gcode_M51(); break;
       case 52: gcode_M52(); break;
       case 53: gcode_M53(); break;
+      case 54: gcode_M54(); break;
       default: parser.unknown_command_error();
     }
     break;

--- a/gcode.h
+++ b/gcode.h
@@ -21,6 +21,7 @@ private:
   void gcode_M51();
   void gcode_M52();
   void gcode_M53();
+  void gcode_M54();
   void process_parsed_command();
   void process_next_command();
   

--- a/ini/SETUP.INI
+++ b/ini/SETUP.INI
@@ -1,2 +1,3 @@
 SSID=xxxx
 PASSWORD=xxxx
+HOSTNAME=xxxx

--- a/network.cpp
+++ b/network.cpp
@@ -19,7 +19,7 @@ bool Network::start() {
   wifiConnecting = true;
   
   // Set hostname first
-  WiFi.hostname(HOSTNAME);
+  WiFi.hostname(config.hostname());
   // Reduce startup surge current
   WiFi.setAutoConnect(false);
   WiFi.mode(WIFI_STA);
@@ -46,7 +46,7 @@ bool Network::start() {
   SERIAL_ECHO("IP address: "); SERIAL_ECHOLN(WiFi.localIP());
   SERIAL_ECHO("RSSI: "); SERIAL_ECHOLN(WiFi.RSSI());
   SERIAL_ECHO("Mode: "); SERIAL_ECHOLN(WiFi.getPhyMode());
-  SERIAL_ECHO("Asscess to SD at the Run prompt : \\\\"); SERIAL_ECHO(WiFi.localIP());SERIAL_ECHOLN("\\DavWWWRoot");
+  SERIAL_ECHO("Access to SD at the Run prompt : \\\\"); SERIAL_ECHO(config.hostname());SERIAL_ECHOLN("\\DavWWWRoot");
 
   wifiConnected = true;
 

--- a/network.h
+++ b/network.h
@@ -1,7 +1,6 @@
 #ifndef _NETWORK_H_
 #define _NETWORK_H_
 
-#define HOSTNAME		"FYSETC"
 #define SERVER_PORT		80
 
 #define WIFI_CONNECT_TIMEOUT 30000UL


### PR DESCRIPTION
Instead of a fixed hostname, it'd be nice if it could be configured.  This would be especially true in a situation where you have more than one SD-WiFi on your network.

This patch enables the hostname to be set, either in setup.ini or with a new ```M54``` gcode.